### PR TITLE
Version code quick fix

### DIFF
--- a/lib/facter/puppetserver_version.rb
+++ b/lib/facter/puppetserver_version.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'facter'
+
+begin
+  Facter.operatinsystem
+rescue
+  Facter.loadfacts()
+end
+
+#If puppetserver is installed..
+if File.exists?('/opt/puppetlabs/bin/puppetserver')
+  puppetserver_version = `/opt/puppetlabs/bin/puppetserver --version`.split(':')[1].chomp.strip
+  Facter.add('puppetserver_version') do
+    setcode do
+      puppetserver_version
+    end
+  end
+end

--- a/templates/server/bootstrap.cfg.erb
+++ b/templates/server/bootstrap.cfg.erb
@@ -15,4 +15,6 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 <% else -%>
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 <% end -%>
+<% if @puppetserver_version and @puppetserver_version >= '2.3.0' -%>
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
+<% end -%>

--- a/templates/server/bootstrap.cfg.erb
+++ b/templates/server/bootstrap.cfg.erb
@@ -15,3 +15,4 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 <% else -%>
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 <% end -%>
+puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service


### PR DESCRIPTION
fixes/should fix

https://tickets.puppetlabs.com/browse/SERVER-1058?_ga=1.36675493.485429227.1446132701

from the 2.3.0 release which doesn't update a modified bootstrap.cfg (which this module does always). 

adds a puppetserver_version fact.  
