### PR TITLE
Fixing agent_config_hash parameter name.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class puppet::params {
   $puppetmaster = "puppet.${::domain}"
   $splay = false
   $splaylimit = undef
-  $admin_config_hash = {}
+  $agent_config_hash = {}
   $cron_cmd_pre = 'MAILTO=""'
   $cron_cmd = 'puppet agent --onetime --no-daemonize'
 


### PR DESCRIPTION
The module tries to gain default value for agent_config_hash from params.pp, but default value does not exist there on that parameter name. Instead a parameter "admin_config_hash" is present in params.pp which isn't referenced anywhere.